### PR TITLE
AcceleratorGenerator architecture suitable for OpenMP/CPU and OpenMP 4.5/GPU

### DIFF
--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/AcceleratorGenerator.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/AcceleratorGenerator.java
@@ -56,30 +56,31 @@ public abstract class AcceleratorGenerator {
    *
    * @return String value that represents the pragma.
    */
-  protected abstract String getStartParallelDirective();
-
-  /**
-   * Get the formatted directive to start the parallelization of a loop.
-   *
-   * @param value Collapse value. if greater than 0, a collapse clause will be
-   *              added to the construct.
-   * @return String value that represents the start of a parallelized loop.
-   */
-  protected abstract String getStartLoopDirective(int value);
-
-  /**
-   * Get the formatted directive to end the parallelization of a loop.
-   *
-   * @return String value that represents the start of a parallelized loop.
-   */
-  protected abstract String getEndLoopDirective();
+  protected abstract String[] getStartParallelDirective(String clauses);
 
   /**
    * Get the end pragma to define a parallel accelerated region.
    *
    * @return String value that represents the pragma.
    */
-  protected abstract String getEndParallelDirective();
+  protected abstract String[] getEndParallelDirective();
+
+  /**
+   * Get the formatted directive to start the parallelization of a loop.
+   *
+   * @param value Collapse value. if greater than 0, a collapse clause will be
+   *              added to the construct.
+   * @param seq   If true, loop should be executed in a sequential mode.
+   * @return String value that represents the start of a parallelized loop.
+   */
+  protected abstract String[] getStartLoopDirective(int value, boolean seq);
+
+  /**
+   * Get the formatted directive to end the parallelization of a loop.
+   *
+   * @return String value that represents the start of a parallelized loop.
+   */
+  protected abstract String[] getEndLoopDirective();
 
   /**
    * Get formatted pragma defined by the accelerator directive prefix and the
@@ -88,7 +89,7 @@ public abstract class AcceleratorGenerator {
    * @param clause Clauses to append to the accelerator directive prefix
    * @return String value that represents the pragma.
    */
-  protected abstract String getSingleDirective(String clause);
+  protected abstract String[] getSingleDirective(String clause);
 
   /**
    * Get the parallel keyword for a given accelerator language.
@@ -130,9 +131,10 @@ public abstract class AcceleratorGenerator {
    * Return the formatted directive to be inserted in a subroutine/function
    * definition.
    *
+   * @param seq Apply sequential mode to the routine directive
    * @return Routine directive.
    */
-  protected abstract String getRoutineDirective();
+  protected abstract String[] getRoutineDirective(boolean seq);
 
 
   /**
@@ -156,14 +158,14 @@ public abstract class AcceleratorGenerator {
    *
    * @return String value that represents the pragma.
    */
-  public abstract String getStartDataRegion();
+  public abstract String[] getStartDataRegion(String clauses);
 
   /**
    * Get the end pragma to define the end of an accelerator data region.
    *
    * @return String value that represents the pragma.
    */
-  public abstract String getEndDataRegion();
+  public abstract String[] getEndDataRegion();
 
   /**
    * Get the corresponding clause to have a sequential execution of an

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/AcceleratorNone.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/AcceleratorNone.java
@@ -6,7 +6,6 @@
 package cx2x.translator.language.helper.accelerator;
 
 import cx2x.translator.config.Configuration;
-import cx2x.translator.language.helper.target.Target;
 
 import java.util.List;
 
@@ -32,27 +31,27 @@ class AcceleratorNone extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getStartParallelDirective() {
+  protected String[] getStartParallelDirective(String clauses) {
     return null;
   }
 
   @Override
-  protected String getStartLoopDirective(int value) {
+  protected String[] getEndParallelDirective() {
     return null;
   }
 
   @Override
-  protected String getEndLoopDirective() {
+  protected String[] getStartLoopDirective(int value, boolean seq) {
     return null;
   }
 
   @Override
-  protected String getEndParallelDirective() {
+  protected String[] getEndLoopDirective() {
     return null;
   }
 
   @Override
-  protected String getSingleDirective(String clause) {
+  protected String[] getSingleDirective(String clause) {
     return null;
   }
 
@@ -77,7 +76,7 @@ class AcceleratorNone extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getRoutineDirective() {
+  protected String[] getRoutineDirective(boolean seq) {
     return null;
   }
 
@@ -92,12 +91,12 @@ class AcceleratorNone extends AcceleratorGenerator {
   }
 
   @Override
-  public String getStartDataRegion() {
+  public String[] getStartDataRegion(String clauses) {
     return null;
   }
 
   @Override
-  public String getEndDataRegion() {
+  public String[] getEndDataRegion() {
     return null;
   }
 

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
@@ -105,7 +105,7 @@ class OpenAcc extends AcceleratorGenerator {
   @Override
   protected String[] getRoutineDirective(boolean seq) {
     //!$acc routine
-    if(seq){
+    if(seq) {
       return new String[]{
           String.format(FORMAT3, OPENACC_PREFIX, OPENACC_ROUTINE,
               getSequentialClause())
@@ -153,17 +153,32 @@ class OpenAcc extends AcceleratorGenerator {
   protected String[] getStartLoopDirective(int value, boolean seq) {
     if(value > 1) {
       //!$acc loop collapse(<value>)
-      return new String[]{
-          String.format(FORMAT4, OPENACC_PREFIX, OPENACC_LOOP,
-              seq ? getSequentialClause() : "",
-              String.format("%s(%d)", OPENACC_COLLAPSE, value))
-      };
+      // TODO do it differently
+      if(seq) {
+        return new String[]{
+            String.format(FORMAT4, OPENACC_PREFIX, OPENACC_LOOP,
+                getSequentialClause(),
+                String.format("%s(%d)", OPENACC_COLLAPSE, value))
+        };
+      } else {
+        return new String[]{
+            String.format(FORMAT3, OPENACC_PREFIX, OPENACC_LOOP,
+                String.format("%s(%d)", OPENACC_COLLAPSE, value))
+        };
+      }
     } else {
       //!$acc loop
-      return new String[]{
-          String.format(FORMAT3, OPENACC_PREFIX, OPENACC_LOOP,
-              seq ? getSequentialClause() : "")
-      };
+      if(seq) {
+        return new String[]{
+            String.format(FORMAT3, OPENACC_PREFIX, OPENACC_LOOP,
+                getSequentialClause())
+        };
+      } else {
+        return new String[]{
+            String.format(FORMAT2, OPENACC_PREFIX, OPENACC_LOOP)
+        };
+      }
+
     }
   }
 

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
@@ -44,22 +44,28 @@ class OpenAcc extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getStartParallelDirective() {
+  protected String[] getStartParallelDirective(String clauses) {
     //!$acc parallel [vector_length()] [num_gang()] [num_worker()]
-    return String.format(FORMAT2, OPENACC_PREFIX, OPENACC_PARALLEL);
+    return new String[]{
+        String.format(FORMAT2, OPENACC_PREFIX, OPENACC_PARALLEL) + " " +
+            clauses
+    };
   }
 
   @Override
-  protected String getEndParallelDirective() {
+  protected String[] getEndParallelDirective() {
     //!$acc end parallel
-    return String.format(FORMAT3,
-        OPENACC_PREFIX, OPENACC_END, OPENACC_PARALLEL);
+    return new String[]{
+        String.format(FORMAT3, OPENACC_PREFIX, OPENACC_END, OPENACC_PARALLEL)
+    };
   }
 
   @Override
-  protected String getSingleDirective(String clause) {
+  protected String[] getSingleDirective(String clause) {
     //!$acc <clause>
-    return String.format(FORMAT2, OPENACC_PREFIX, clause);
+    return new String[]{
+        String.format(FORMAT2, OPENACC_PREFIX, clause)
+    };
   }
 
   @Override
@@ -97,9 +103,12 @@ class OpenAcc extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getRoutineDirective() {
+  protected String[] getRoutineDirective(boolean seq) {
     //!$acc routine
-    return String.format(FORMAT2, OPENACC_PREFIX, OPENACC_ROUTINE);
+    return new String[]{
+        String.format(FORMAT3, OPENACC_PREFIX, OPENACC_ROUTINE,
+            seq ? getSequentialClause() : "")
+    };
   }
 
   @Override
@@ -114,15 +123,19 @@ class OpenAcc extends AcceleratorGenerator {
   }
 
   @Override
-  public String getStartDataRegion() {
+  public String[] getStartDataRegion(String clauses) {
     //!$acc data
-    return String.format(FORMAT2, OPENACC_PREFIX, OPENACC_DATA);
+    return new String[]{
+        String.format(FORMAT2, OPENACC_PREFIX, OPENACC_DATA) + " " + clauses
+    };
   }
 
   @Override
-  public String getEndDataRegion() {
+  public String[] getEndDataRegion() {
     //!$acc end data
-    return String.format(FORMAT3, OPENACC_PREFIX, OPENACC_END, OPENACC_DATA);
+    return new String[]{
+        String.format(FORMAT3, OPENACC_PREFIX, OPENACC_END, OPENACC_DATA)
+    };
   }
 
   @Override
@@ -131,19 +144,25 @@ class OpenAcc extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getStartLoopDirective(int value) {
+  protected String[] getStartLoopDirective(int value, boolean seq) {
     if(value > 1) {
       //!$acc loop collapse(<value>)
-      return String.format(FORMAT3, OPENACC_PREFIX, OPENACC_LOOP,
-          String.format("%s(%d)", OPENACC_COLLAPSE, value));
+      return new String[]{
+          String.format(FORMAT4, OPENACC_PREFIX, OPENACC_LOOP,
+              seq ? getSequentialClause() : "",
+              String.format("%s(%d)", OPENACC_COLLAPSE, value))
+      };
     } else {
       //!$acc loop
-      return String.format(FORMAT2, OPENACC_PREFIX, OPENACC_LOOP);
+      return new String[]{
+          String.format(FORMAT3, OPENACC_PREFIX, OPENACC_LOOP,
+              seq ? getSequentialClause() : "")
+      };
     }
   }
 
   @Override
-  protected String getEndLoopDirective() {
+  protected String[] getEndLoopDirective() {
     return null;
   }
 }

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
@@ -46,6 +46,11 @@ class OpenAcc extends AcceleratorGenerator {
   @Override
   protected String[] getStartParallelDirective(String clauses) {
     //!$acc parallel [vector_length()] [num_gang()] [num_worker()]
+    if(clauses == null || clauses.isEmpty()){
+      return new String[]{
+          String.format(FORMAT2, OPENACC_PREFIX, OPENACC_PARALLEL)
+      };
+    }
     return new String[]{
         String.format(FORMAT2, OPENACC_PREFIX, OPENACC_PARALLEL) + " " +
             clauses

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenAcc.java
@@ -105,10 +105,16 @@ class OpenAcc extends AcceleratorGenerator {
   @Override
   protected String[] getRoutineDirective(boolean seq) {
     //!$acc routine
-    return new String[]{
-        String.format(FORMAT3, OPENACC_PREFIX, OPENACC_ROUTINE,
-            seq ? getSequentialClause() : "")
-    };
+    if(seq){
+      return new String[]{
+          String.format(FORMAT3, OPENACC_PREFIX, OPENACC_ROUTINE,
+              getSequentialClause())
+      };
+    } else {
+      return new String[]{
+          String.format(FORMAT2, OPENACC_PREFIX, OPENACC_ROUTINE)
+      };
+    }
   }
 
   @Override

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenMp.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenMp.java
@@ -42,35 +42,46 @@ class OpenMp extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getStartParallelDirective() {
+  protected String[] getStartParallelDirective(String clauses) {
+    // TODO handle possible clauses
     if(getConfiguration().getCurrentTarget() == Target.GPU) {
-      //!$omp target parallel
-      return String.format(FORMAT3,
-          OPENMP_PREFIX, OPENMP_TARGET, OPENMP_PARALLEL);
+      //!$omp target
+      //!$omp parallel
+      return new String[]{
+          String.format(FORMAT2, OPENMP_PREFIX, OPENMP_TARGET),
+          String.format(FORMAT2, OPENMP_PREFIX, OPENMP_PARALLEL)
+      };
     } else {
       //!$omp parallel
-      return String.format(FORMAT2,
-          OPENMP_PREFIX, OPENMP_PARALLEL);
+      return new String[]{
+          String.format(FORMAT2, OPENMP_PREFIX, OPENMP_PARALLEL)
+      };
     }
   }
 
   @Override
-  public String getEndParallelDirective() {
+  public String[] getEndParallelDirective() {
     if(getConfiguration().getCurrentTarget() == Target.GPU) {
-      //!$omp end target parallel
-      return String.format(FORMAT4,
-          OPENMP_PREFIX, OPENMP_END, OPENMP_TARGET, OPENMP_PARALLEL);
+      //!$omp end parallel
+      //!$omp end target
+      return new String[]{
+          String.format(FORMAT3, OPENMP_PREFIX, OPENMP_END, OPENMP_PARALLEL),
+          String.format(FORMAT3, OPENMP_PREFIX, OPENMP_END, OPENMP_TARGET)
+      };
     } else {
       //!$omp end parallel
-      return String.format(FORMAT3,
-          OPENMP_PREFIX, OPENMP_END, OPENMP_PARALLEL);
+      return new String[]{
+          String.format(FORMAT3, OPENMP_PREFIX, OPENMP_END, OPENMP_PARALLEL)
+      };
     }
   }
 
   @Override
-  public String getSingleDirective(String clause) {
+  public String[] getSingleDirective(String clause) {
     //!$omp <clause>
-    return String.format(FORMAT2, OPENMP_PREFIX, clause);
+    return new String[]{
+        String.format(FORMAT2, OPENMP_PREFIX, clause)
+    };
   }
 
   @Override
@@ -97,9 +108,11 @@ class OpenMp extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getRoutineDirective() {
+  protected String[] getRoutineDirective(boolean seq) {
     // TODO check
-    return String.format(FORMAT3, OPENMP_PREFIX, OPENMP_DECLARE, OPENMP_TARGET);
+    return new String[]{
+        String.format(FORMAT3, OPENMP_PREFIX, OPENMP_DECLARE, OPENMP_TARGET)
+    };
   }
 
   @Override
@@ -114,12 +127,12 @@ class OpenMp extends AcceleratorGenerator {
   }
 
   @Override
-  public String getStartDataRegion() {
+  public String[] getStartDataRegion(String clauses) {
     return null; // TODO OpenMP 4.5
   }
 
   @Override
-  public String getEndDataRegion() {
+  public String[] getEndDataRegion() {
     return null; // TODO OpenMP 4.5
   }
 
@@ -129,16 +142,21 @@ class OpenMp extends AcceleratorGenerator {
   }
 
   @Override
-  protected String getStartLoopDirective(int value) {
+  protected String[] getStartLoopDirective(int value, boolean seq) {
     // TODO CPU/GPU difference
+    // TODO handle seq argument
     //!$omp do
-    return String.format(FORMAT2, OPENMP_PREFIX, OPENMP_DO);
+    return new String[]{
+        String.format(FORMAT2, OPENMP_PREFIX, OPENMP_DO)
+    };
   }
 
   @Override
-  protected String getEndLoopDirective() {
+  protected String[] getEndLoopDirective() {
     // TODO CPU/GPU difference
     //!$omp end do
-    return String.format(FORMAT3, OPENMP_PREFIX, OPENMP_END, OPENMP_DO);
+    return new String[]{
+        String.format(FORMAT3, OPENMP_PREFIX, OPENMP_END, OPENMP_DO)
+    };
   }
 }

--- a/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenMp.java
+++ b/omni-cx2x/src/cx2x/translator/language/helper/accelerator/OpenMp.java
@@ -43,27 +43,27 @@ class OpenMp extends AcceleratorGenerator {
 
   @Override
   protected String getStartParallelDirective() {
-    if(getConfiguration().getCurrentTarget() == Target.CPU) {
+    if(getConfiguration().getCurrentTarget() == Target.GPU) {
+      //!$omp target parallel
+      return String.format(FORMAT3,
+          OPENMP_PREFIX, OPENMP_TARGET, OPENMP_PARALLEL);
+    } else {
       //!$omp parallel
       return String.format(FORMAT2,
           OPENMP_PREFIX, OPENMP_PARALLEL);
-    } else {
-      //!$omp target parallel do
-      return String.format(FORMAT3,
-          OPENMP_PREFIX, OPENMP_TARGET, OPENMP_PARALLEL);
     }
   }
 
   @Override
   public String getEndParallelDirective() {
-    if(getConfiguration().getCurrentTarget() == Target.CPU) {
+    if(getConfiguration().getCurrentTarget() == Target.GPU) {
+      //!$omp end target parallel
+      return String.format(FORMAT4,
+          OPENMP_PREFIX, OPENMP_END, OPENMP_TARGET, OPENMP_PARALLEL);
+    } else {
       //!$omp end parallel
       return String.format(FORMAT3,
           OPENMP_PREFIX, OPENMP_END, OPENMP_PARALLEL);
-    } else {
-      //!$omp end target parallel do
-      return String.format(FORMAT4,
-          OPENMP_PREFIX, OPENMP_END, OPENMP_TARGET, OPENMP_PARALLEL);
     }
   }
 
@@ -115,17 +115,17 @@ class OpenMp extends AcceleratorGenerator {
 
   @Override
   public String getStartDataRegion() {
-    return null; // TODO OpenMP
+    return null; // TODO OpenMP 4.5
   }
 
   @Override
   public String getEndDataRegion() {
-    return null; // TODO OpenMP
+    return null; // TODO OpenMP 4.5
   }
 
   @Override
   public String getSequentialClause() {
-    return null; // TODO OpenMP if makes sense
+    return null; // TODO OpenMP 4.5
   }
 
   @Override


### PR DESCRIPTION
Adapt the `AcceleratorGenerator` to be able to generate directives for OpenMP 4.5. This means essentially to be able to generate 1 to n directive for a single call to `AcceleratorGenerator` methods.
Currently, this is fixed. 