### PR TITLE
Fix FPP for Cray and OpenMP

### DIFF
--- a/compiler/cray.cmake
+++ b/compiler/cray.cmake
@@ -1,5 +1,5 @@
 # For Cray Compiler
-set(FPPFLAGS "-e P")                  # for preprocessing only
+set(FPPFLAGS "-e P -hnoomp")          # for preprocessing only
 set(FPP_REDIRECT false)               # cannot use redirection > to save file
 set(CLAW_TEST_FFP_FLAGS "-e Z")       # for preprocessing and compilation
 set(TEST_BASE_FLAGS "-h noacc,noomp") # Unactivate OpenACC and OpenMP


### PR DESCRIPTION
Cray enable OpenMP by default and it causes problem when using FPP in CLAW driver for GPU traget