### PR TITLE
Implements constraint clause for loop-fusion directive + more flexiblity in loop-hoist

### DIFF
--- a/omni-cx2x/src/cx2x/translator/ClawXcodeMlTranslator.java
+++ b/omni-cx2x/src/cx2x/translator/ClawXcodeMlTranslator.java
@@ -378,8 +378,8 @@ public class ClawXcodeMlTranslator {
         System.err.println(String.format("%s %s, line: undefined", prefix,
             message.getMessage()));
       } else {
-        System.err.println(String.format("%s %s, line: %d", prefix,
-            message.getMessage(), message.getLine()));
+        System.err.println(String.format("%s %s, line: %s", prefix,
+            message.getMessage(), message.getConcatLines()));
       }
     }
     messages.clear();

--- a/omni-cx2x/src/cx2x/translator/language/base/ClawLanguage.java
+++ b/omni-cx2x/src/cx2x/translator/language/base/ClawLanguage.java
@@ -5,10 +5,7 @@
 
 package cx2x.translator.language.base;
 
-import cx2x.translator.language.common.ClawDimension;
-import cx2x.translator.language.common.ClawMapping;
-import cx2x.translator.language.common.ClawRange;
-import cx2x.translator.language.common.ClawReshapeInfo;
+import cx2x.translator.language.common.*;
 import cx2x.translator.language.helper.accelerator.AcceleratorDirective;
 import cx2x.translator.language.helper.accelerator.AcceleratorGenerator;
 import cx2x.translator.language.helper.target.Target;
@@ -62,6 +59,7 @@ public class ClawLanguage extends AnalyzedPragma {
   private ClawDMD _copyClauseValue;
   private ClawDMD _updateClauseValue;
   private List<Target> _targetClauseValues;
+  private ClawConstraint _constraintClauseValue;
 
   // Clauses flags
   private boolean _hasAccClause, _hasCollapseClause, _hasDataClause;
@@ -70,7 +68,7 @@ public class ClawLanguage extends AnalyzedPragma {
   private boolean _hasInterchangeClause, _hasOverClause, _hasParallelClause;
   private boolean _hasPrivateClause, _hasReshapeClause, _hasForward;
   private boolean _hasOverDataClause, _hasCopyClause, _hasUpdateClause;
-  private boolean _hasTargetClause;
+  private boolean _hasTargetClause, _hasConstraintClause;
 
   /**
    * Constructs an empty ClawLanguage section.
@@ -257,6 +255,7 @@ public class ClawLanguage extends AnalyzedPragma {
     _rangeValue = null;
     _reshapeInfos = null;
     _targetClauseValues = null;
+    _constraintClauseValue = ClawConstraint.BLOCK;
 
     // Clauses flags members
     _hasAccClause = false;
@@ -277,6 +276,7 @@ public class ClawLanguage extends AnalyzedPragma {
     _hasReshapeClause = false;
     _hasUpdateClause = false;
     _hasTargetClause = false;
+    _hasConstraintClause = false;
 
     // General members
     _directive = null;
@@ -922,6 +922,34 @@ public class ClawLanguage extends AnalyzedPragma {
   public void setTargetClauseValue(List<Target> values) {
     _hasTargetClause = true;
     _targetClauseValues = values;
+  }
+
+  /**
+   * Check whether the constraint clause is used.
+   *
+   * @return True if the constraint clause is used.
+   */
+  public boolean hasConstraintClause() {
+    return _hasConstraintClause;
+  }
+
+  /**
+   * Get the constraint clause value.
+   *
+   * @return Constraint clause value as an enum value.
+   */
+  public ClawConstraint getConstraintClauseValue() {
+    return _constraintClauseValue;
+  }
+
+  /**
+   * Set the constraint clause value and the update clause usage flag to true.
+   *
+   * @param value New constraint clause value.
+   */
+  public void setConstraintClauseValue(ClawConstraint value) {
+    _hasConstraintClause = true;
+    _constraintClauseValue = value;
   }
 
   /**

--- a/omni-cx2x/src/cx2x/translator/language/base/ClawLanguage.java
+++ b/omni-cx2x/src/cx2x/translator/language/base/ClawLanguage.java
@@ -255,7 +255,7 @@ public class ClawLanguage extends AnalyzedPragma {
     _rangeValue = null;
     _reshapeInfos = null;
     _targetClauseValues = null;
-    _constraintClauseValue = ClawConstraint.BLOCK;
+    _constraintClauseValue = ClawConstraint.DIRECT;
 
     // Clauses flags members
     _hasAccClause = false;

--- a/omni-cx2x/src/cx2x/translator/language/common/ClawConstraint.java
+++ b/omni-cx2x/src/cx2x/translator/language/common/ClawConstraint.java
@@ -1,0 +1,16 @@
+/*
+ * This file is released under terms of BSD license
+ * See LICENSE file for more information
+ */
+
+package cx2x.translator.language.common;
+
+/**
+ * Define the value of the conatrsint clause
+ *
+ * @author clementval
+ */
+public enum ClawConstraint {
+  NONE,
+  BLOCK
+}

--- a/omni-cx2x/src/cx2x/translator/language/common/ClawConstraint.java
+++ b/omni-cx2x/src/cx2x/translator/language/common/ClawConstraint.java
@@ -12,5 +12,5 @@ package cx2x.translator.language.common;
  */
 public enum ClawConstraint {
   NONE,
-  BLOCK
+  DIRECT
 }

--- a/omni-cx2x/src/cx2x/translator/language/parser/Claw.g4
+++ b/omni-cx2x/src/cx2x/translator/language/parser/Claw.g4
@@ -407,8 +407,8 @@ target_clause[ClawLanguage l]
 constraint_clause[ClawLanguage l]:
     CONSTRAINT '(' NONE ')'
     { $l.setConstraintClauseValue(ClawConstraint.NONE); }
-  | CONSTRAINT '(' BLOCK ')'
-    { $l.setConstraintClauseValue(ClawConstraint.BLOCK); }
+  | CONSTRAINT '(' DIRECT ')'
+    { $l.setConstraintClauseValue(ClawConstraint.DIRECT); }
 ;
 
 target_list[List<Target> targets]:
@@ -552,7 +552,7 @@ GPU          : 'gpu';
 MIC          : 'mic';
 
 // Constraint clause value
-BLOCK        : 'block';
+DIRECT       : 'direct';
 NONE         : 'none';
 
 // Special elements

--- a/omni-cx2x/src/cx2x/translator/language/parser/Claw.g4
+++ b/omni-cx2x/src/cx2x/translator/language/parser/Claw.g4
@@ -404,6 +404,13 @@ target_clause[ClawLanguage l]
     { $l.setTargetClauseValue(targets); }
 ;
 
+constraint_clause[ClawLanguage l]:
+    CONSTRAINT '(' NONE ')'
+    { $l.setConstraintClauseValue(ClawConstraint.NONE); }
+  | CONSTRAINT '(' BLOCK ')'
+    { $l.setConstraintClauseValue(ClawConstraint.BLOCK); }
+;
+
 target_list[List<Target> targets]:
     target { if(!$targets.contains($target.t)) { $targets.add($target.t); } }
   | target { if(!$targets.contains($target.t)) { $targets.add($target.t); } } ',' target_list[$targets]
@@ -419,9 +426,10 @@ target returns [Target t]:
 // Possible permutation of clauses for the loop-fusion directive
 loop_fusion_clauses[ClawLanguage l]:
   (
-    { !$l.hasGroupClause() }?    group_clause[$l]
-  | { !$l.hasCollapseClause() }? collapse_clause[$l]
-  | { !$l.hasTargetClause() }?   target_clause[$l]
+    { !$l.hasGroupClause() }?      group_clause[$l]
+  | { !$l.hasCollapseClause() }?   collapse_clause[$l]
+  | { !$l.hasTargetClause() }?     target_clause[$l]
+  | { !$l.hasConstraintClause() }? constraint_clause[$l]
   )*
 ;
 
@@ -510,6 +518,7 @@ VERBATIM         : 'verbatim';
 
 // CLAW Clauses
 COLLAPSE     : 'collapse';
+CONSTRAINT   : 'constraint';
 COPY         : 'copy';
 DATA         : 'data';
 DIMENSION    : 'dimension';
@@ -541,6 +550,10 @@ OMP          : 'omp';
 CPU          : 'cpu';
 GPU          : 'gpu';
 MIC          : 'mic';
+
+// Constraint clause value
+BLOCK        : 'block';
+NONE         : 'none';
 
 // Special elements
 IDENTIFIER      : [a-zA-Z_$] [a-zA-Z_$0-9-]* ;

--- a/omni-cx2x/src/cx2x/translator/transformation/ClawTransformation.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/ClawTransformation.java
@@ -26,4 +26,12 @@ public abstract class ClawTransformation extends Transformation {
     _claw = directive;
   }
 
+  /**
+   * Get the language information object.
+   * @return ClawLanguage with information gathered at parsing time.
+   */
+  public ClawLanguage getLanguageInfo(){
+    return _claw;
+  }
+
 }

--- a/omni-cx2x/src/cx2x/translator/transformation/claw/ArrayToFctCall.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/claw/ArrayToFctCall.java
@@ -75,8 +75,14 @@ public class ArrayToFctCall extends ClawTransformation {
     return true; // skeleton
   }
 
+  /**
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
+   */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     return false; // independent transformation
   }
 

--- a/omni-cx2x/src/cx2x/translator/transformation/claw/Kcaching.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/claw/Kcaching.java
@@ -54,10 +54,13 @@ public class Kcaching extends ClawTransformation {
   }
 
   /**
-   * @see Transformation#canBeTransformedWith(Transformation)
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
    */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     // independent transformation
     return false;
   }

--- a/omni-cx2x/src/cx2x/translator/transformation/claw/parallelize/Parallelize.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/claw/parallelize/Parallelize.java
@@ -689,9 +689,14 @@ public class Parallelize extends ClawTransformation {
     }
   }
 
-
+  /**
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
+   */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     return false; // This is an independent transformation
   }
 }

--- a/omni-cx2x/src/cx2x/translator/transformation/claw/parallelize/ParallelizeForward.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/claw/parallelize/ParallelizeForward.java
@@ -823,8 +823,14 @@ public class ParallelizeForward extends ClawTransformation {
     }
   }
 
+  /**
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
+   */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     return false; // independent transformation
   }
 

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/ArrayTransform.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/ArrayTransform.java
@@ -136,10 +136,13 @@ public class ArrayTransform extends ClawBlockTransformation {
   }
 
   /**
-   * @see Transformation#canBeTransformedWith(Transformation)
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
    */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     // independent transformation
     return false;
   }

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopExtraction.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopExtraction.java
@@ -519,10 +519,12 @@ public class LoopExtraction extends ClawTransformation {
 
   /**
    * @return Always false as independent transformation are applied one by one.
-   * @see Transformation#canBeTransformedWith(Transformation)
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
    */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     // independent transformation
     return false;
   }

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopFusion.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopFusion.java
@@ -213,7 +213,7 @@ public class LoopFusion extends ClawTransformation {
       return false;
     }
 
-    ClawConstraint currentConstraint = ClawConstraint.BLOCK;
+    ClawConstraint currentConstraint = ClawConstraint.DIRECT;
     if(_claw.hasConstraintClause()
         && other.getLanguageInfo().hasConstraintClause())
     {
@@ -235,12 +235,7 @@ public class LoopFusion extends ClawTransformation {
 
     // Following constraint are used only in default mode. If constraint clause
     // is set to none, there are note checked.
-    if(currentConstraint == ClawConstraint.BLOCK) {
-      // Loops can only be merged if they are at the same level
-      if(!XnodeUtil.hasSameParentBlock(_doStmts[0], other.getDoStmtAtIndex(0))) {
-        return false;
-      }
-
+    if(currentConstraint == ClawConstraint.DIRECT) {
       // Only pragma statement can be between the two loops.
       if(!XnodeUtil.isDirectSibling(_doStmts[0], other.getDoStmtAtIndex(0),
           Collections.singletonList(Xcode.FPRAGMASTATEMENT)))
@@ -251,6 +246,11 @@ public class LoopFusion extends ClawTransformation {
       xcodeml.addWarning("Unconstrained loop-fusion generated",
           Arrays.asList(_claw.getPragma().lineNo(),
               other.getLanguageInfo().getPragma().lineNo()));
+    }
+
+    // Loops can only be merged if they are at the same level
+    if(!XnodeUtil.hasSameParentBlock(_doStmts[0], other.getDoStmtAtIndex(0))) {
+      return false;
     }
 
     if(_claw.hasCollapseClause() && _claw.getCollapseValue() > 0) {

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopFusion.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopFusion.java
@@ -17,6 +17,7 @@ import cx2x.xcodeml.xnode.Xcode;
 import cx2x.xcodeml.xnode.XcodeProgram;
 import cx2x.xcodeml.xnode.Xnode;
 
+import java.util.Arrays;
 import java.util.Collections;
 
 /**
@@ -248,7 +249,8 @@ public class LoopFusion extends ClawTransformation {
       }
     } else {
       xcodeml.addWarning("Unconstrained loop-fusion generated",
-          _claw.getPragma().lineNo());
+          Arrays.asList(_claw.getPragma().lineNo(),
+              other.getLanguageInfo().getPragma().lineNo()));
     }
 
     if(_claw.hasCollapseClause() && _claw.getCollapseValue() > 0) {

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopFusion.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopFusion.java
@@ -194,7 +194,9 @@ public class LoopFusion extends ClawTransformation {
    * @return True if the two loop fusion unit can be merge together.
    */
   @Override
-  public boolean canBeTransformedWith(Transformation transformation) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation transformation)
+  {
     if(!(transformation instanceof LoopFusion)) {
       return false;
     }
@@ -244,6 +246,9 @@ public class LoopFusion extends ClawTransformation {
       {
         return false;
       }
+    } else {
+      xcodeml.addWarning("Unconstrained loop-fusion generated",
+          _claw.getPragma().lineNo());
     }
 
     if(_claw.hasCollapseClause() && _claw.getCollapseValue() > 0) {

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopHoist.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopHoist.java
@@ -81,7 +81,8 @@ public class LoopHoist extends ClawBlockTransformation {
       if(depth != _pragmaDepthLevel) {
         Xnode tmpIf = group[0].matchAncestor(Xcode.FIFSTATEMENT);
         Xnode tmpSelect = group[0].matchAncestor(Xcode.FSELECTCASESTATEMENT);
-        if(tmpIf == null && tmpSelect == null) {
+        Xnode tmpDo = group[0].matchAncestor(Xcode.FDOSTATEMENT);
+        if(tmpIf == null && tmpSelect == null && tmpDo == null) {
           xcodeml.addError("Group " + i + " is nested in an unsupported " +
                   "statement for loop hoisting (Group index starts at 0).",
               _clawStart.getPragma().lineNo());
@@ -92,9 +93,12 @@ public class LoopHoist extends ClawBlockTransformation {
             (tmpIf != null) ? tmpIf.depth() : Xnode.UNDEF_DEPTH;
         int selectDepth =
             (tmpSelect != null) ? tmpSelect.depth() : Xnode.UNDEF_DEPTH;
+        int doDepth =
+            (tmpDo != null) ? tmpDo.depth() : Xnode.UNDEF_DEPTH;
 
-        if((_pragmaDepthLevel <= ifDepth || _pragmaDepthLevel <= selectDepth)
-            && (ifDepth < depth || selectDepth < depth))
+        if((_pragmaDepthLevel <= ifDepth || _pragmaDepthLevel <= selectDepth
+            || _pragmaDepthLevel <= doDepth)
+            && (ifDepth < depth || selectDepth < depth || doDepth < depth))
         {
           crtGroup.setExtraction();
         } else {

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopHoist.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopHoist.java
@@ -186,10 +186,13 @@ public class LoopHoist extends ClawBlockTransformation {
   }
 
   /**
-   * @see Transformation#canBeTransformedWith(Transformation)
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
    */
   @Override
-  public boolean canBeTransformedWith(Transformation transformation) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation transformation)
+  {
     return false;
   }
 

--- a/omni-cx2x/src/cx2x/translator/transformation/loop/LoopInterchange.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/loop/LoopInterchange.java
@@ -243,10 +243,12 @@ public class LoopInterchange extends ClawTransformation {
 
   /**
    * @return Always false as independent transformation are applied one by one.
-   * @see Transformation#canBeTransformedWith(Transformation)
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
    */
   @Override
-  public boolean canBeTransformedWith(Transformation transformation) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation transformation)
+  {
     // independent transformation
     return false;
   }

--- a/omni-cx2x/src/cx2x/translator/transformation/openacc/DirectivePrimitive.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/openacc/DirectivePrimitive.java
@@ -45,8 +45,14 @@ public class DirectivePrimitive extends ClawTransformation {
     return true;
   }
 
+  /**
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
+   */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     // independent transformation
     return false;
   }

--- a/omni-cx2x/src/cx2x/translator/transformation/openacc/OpenAccContinuation.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/openacc/OpenAccContinuation.java
@@ -63,8 +63,14 @@ public class OpenAccContinuation extends Transformation {
         startsWith(ClawConstant.OPENACC_PREFIX);
   }
 
+  /**
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
+   */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     // independent transformation
     return false;
   }

--- a/omni-cx2x/src/cx2x/translator/transformation/utility/UtilityRemove.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/utility/UtilityRemove.java
@@ -98,10 +98,13 @@ public class UtilityRemove extends ClawBlockTransformation {
   }
 
   /**
-   * @see Transformation#canBeTransformedWith(Transformation)
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
    */
   @Override
-  public boolean canBeTransformedWith(Transformation transformation) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation transformation)
+  {
     return true; // Always true as independent transformation
   }
 

--- a/omni-cx2x/src/cx2x/translator/transformation/utility/XcodeMLWorkaround.java
+++ b/omni-cx2x/src/cx2x/translator/transformation/utility/XcodeMLWorkaround.java
@@ -35,8 +35,14 @@ public class XcodeMLWorkaround extends ClawTransformation {
     return true;
   }
 
+  /**
+   * @return Always false as independent transformation are applied one by one.
+   * @see Transformation#canBeTransformedWith(XcodeProgram, Transformation)
+   */
   @Override
-  public boolean canBeTransformedWith(Transformation other) {
+  public boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                      Transformation other)
+  {
     return false; // Independent transformation
   }
 

--- a/omni-cx2x/src/cx2x/xcodeml/error/XanalysisError.java
+++ b/omni-cx2x/src/cx2x/xcodeml/error/XanalysisError.java
@@ -5,6 +5,11 @@
 
 package cx2x.xcodeml.error;
 
+import cx2x.translator.common.Utility;
+
+import java.util.ArrayList;
+import java.util.List;
+
 /**
  * This class hold information about error happening during transformation
  * analysis.
@@ -15,7 +20,7 @@ package cx2x.xcodeml.error;
 public class XanalysisError {
 
   private final String _errorMsg;
-  private final int _errorLineNumber;
+  private final List<Integer> _errorLineNumbers;
 
   /**
    * Default ctor.
@@ -25,7 +30,23 @@ public class XanalysisError {
    */
   public XanalysisError(String msg, int lineno) {
     _errorMsg = msg;
-    _errorLineNumber = lineno;
+    _errorLineNumbers = new ArrayList<>();
+    _errorLineNumbers.add(lineno);
+  }
+
+  /**
+   * Default ctor with more than one line number.
+   *
+   * @param msg    Error message
+   * @param lineno Line numbers that triggered the error.
+   */
+  public XanalysisError(String msg, List<Integer> lineno) {
+    _errorMsg = msg;
+    if(lineno == null){
+      _errorLineNumbers = new ArrayList<>();
+    } else {
+      _errorLineNumbers = lineno;
+    }
   }
 
   /**
@@ -36,9 +57,25 @@ public class XanalysisError {
   }
 
   /**
-   * @return The line number that triggered the error.
+   * @return The first line number that triggered the error.
    */
   public int getLine() {
-    return _errorLineNumber;
+    return _errorLineNumbers.get(0);
+  }
+
+
+  /**
+   * @return The line numbers that triggered the error.
+   */
+  public List<Integer> getLines() {
+    return _errorLineNumbers;
+  }
+
+  /**
+   * String concatenation of the lines present in the error/warning.
+   * @return String value of the line numbers.
+   */
+  public String getConcatLines() {
+    return Utility.join(",", _errorLineNumbers);
   }
 }

--- a/omni-cx2x/src/cx2x/xcodeml/transformation/DependentTransformationGroup.java
+++ b/omni-cx2x/src/cx2x/xcodeml/transformation/DependentTransformationGroup.java
@@ -43,7 +43,7 @@ public class DependentTransformationGroup extends TransformationGroup {
         if(candidate.isTransformed()) {
           continue;
         }
-        if(base.canBeTransformedWith(candidate)) {
+        if(base.canBeTransformedWith(xcodeml, candidate)) {
           try {
             base.transform(xcodeml, transformer, candidate);
           } catch(IllegalTransformationException itex) {

--- a/omni-cx2x/src/cx2x/xcodeml/transformation/Transformation.java
+++ b/omni-cx2x/src/cx2x/xcodeml/transformation/Transformation.java
@@ -53,12 +53,14 @@ public abstract class Transformation {
    * Check whether the current transformation can be transformed together with
    * the given transformation. Useful only for dependent transformation.
    *
+   * @param xcodeml     The XcodeML on which the transformations are applied.
    * @param other The other transformation part of the dependent transformation.
    * @return True if the two transformation can be transform together. False
    * otherwise.
    * @see DependentTransformationGroup
    */
-  public abstract boolean canBeTransformedWith(Transformation other);
+  public abstract boolean canBeTransformedWith(XcodeProgram xcodeml,
+                                               Transformation other);
 
   /**
    * Apply the actual transformation.

--- a/omni-cx2x/src/cx2x/xcodeml/xnode/XcodeProgram.java
+++ b/omni-cx2x/src/cx2x/xcodeml/xnode/XcodeProgram.java
@@ -123,6 +123,16 @@ public class XcodeProgram extends XcodeML {
   }
 
   /**
+   * Add a warning.
+   *
+   * @param msg    Warning message.
+   * @param lineno Line numbers that triggered the warning.
+   */
+  public void addWarning(String msg, List<Integer> lineno) {
+    _warnings.add(new XanalysisError(msg, lineno));
+  }
+
+  /**
    * Get all the warnings.
    *
    * @return A list containing all the warnings.

--- a/omni-cx2x/unittest/cx2x/translator/language/ClawLanguageTest.java
+++ b/omni-cx2x/unittest/cx2x/translator/language/ClawLanguageTest.java
@@ -76,11 +76,11 @@ public class ClawLanguageTest {
         "group(g1)", "g1", true, 3, Arrays.asList(Target.CPU, Target.GPU), null);
 
     // Constraint clause
-    analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(block)",
+    analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(direct)",
         "g1", false, 0, null, ClawConstraint.DIRECT);
     analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(none)",
         "g1", false, 0, null, ClawConstraint.NONE);
-    analyzeValidClawLoopFusion("claw loop-fusion constraint(block)",
+    analyzeValidClawLoopFusion("claw loop-fusion constraint(direct)",
         null, false, 0, null, ClawConstraint.DIRECT);
     analyzeValidClawLoopFusion("claw loop-fusion constraint(none)",
         null, false, 0, null, ClawConstraint.NONE);

--- a/omni-cx2x/unittest/cx2x/translator/language/ClawLanguageTest.java
+++ b/omni-cx2x/unittest/cx2x/translator/language/ClawLanguageTest.java
@@ -77,11 +77,11 @@ public class ClawLanguageTest {
 
     // Constraint clause
     analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(block)",
-        "g1", false, 0, null, ClawConstraint.BLOCK);
+        "g1", false, 0, null, ClawConstraint.DIRECT);
     analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(none)",
         "g1", false, 0, null, ClawConstraint.NONE);
     analyzeValidClawLoopFusion("claw loop-fusion constraint(block)",
-        null, false, 0, null, ClawConstraint.BLOCK);
+        null, false, 0, null, ClawConstraint.DIRECT);
     analyzeValidClawLoopFusion("claw loop-fusion constraint(none)",
         null, false, 0, null, ClawConstraint.NONE);
 

--- a/omni-cx2x/unittest/cx2x/translator/language/ClawLanguageTest.java
+++ b/omni-cx2x/unittest/cx2x/translator/language/ClawLanguageTest.java
@@ -9,6 +9,7 @@ import cx2x.translator.config.Configuration;
 import cx2x.translator.language.base.ClawDMD;
 import cx2x.translator.language.base.ClawDirective;
 import cx2x.translator.language.base.ClawLanguage;
+import cx2x.translator.language.common.ClawConstraint;
 import cx2x.translator.language.common.ClawDimension;
 import cx2x.translator.language.common.ClawMapping;
 import cx2x.translator.language.common.ClawReshapeInfo;
@@ -40,39 +41,49 @@ public class ClawLanguageTest {
   @Test
   public void FusionTest() {
     // Valid directives
-    analyzeValidClawLoopFusion("claw loop-fusion", null, false, 0, null);
+    analyzeValidClawLoopFusion("claw loop-fusion", null, false, 0, null, null);
     analyzeValidClawLoopFusion("claw loop-fusion group(g1)", "g1", false, 0,
-        null);
+        null, null);
     analyzeValidClawLoopFusion("claw loop-fusion group( g1 )", "g1", false, 0,
-        null);
+        null, null);
     analyzeValidClawLoopFusion("claw loop-fusion group ( g1   ) ", "g1",
-        false, 0, null);
+        false, 0, null, null);
     analyzeValidClawLoopFusion("claw loop-fusion group(g1) collapse(2)", "g1",
-        true, 2, null);
+        true, 2, null, null);
     analyzeValidClawLoopFusion("claw loop-fusion group(g1) collapse(3)", "g1",
-        true, 3, null);
+        true, 3, null, null);
     analyzeValidClawLoopFusion("claw loop-fusion collapse(3) group(g1)", "g1",
-        true, 3, null);
+        true, 3, null, null);
     analyzeValidClawLoopFusion("claw loop-fusion collapse(2)", null,
-        true, 2, null);
+        true, 2, null, null);
     analyzeValidClawLoopFusion("claw loop-fusion collapse(3)", null,
-        true, 3, null);
+        true, 3, null, null);
 
     // With target clause
     analyzeValidClawLoopFusion("claw loop-fusion target(cpu)", null, false, 0,
-        Collections.singletonList(Target.CPU));
+        Collections.singletonList(Target.CPU), null);
     analyzeValidClawLoopFusion("claw loop-fusion target(gpu)", null, false, 0,
-        Collections.singletonList(Target.GPU));
+        Collections.singletonList(Target.GPU), null);
     analyzeValidClawLoopFusion("claw loop-fusion target(mic)", null, false, 0,
-        Collections.singletonList(Target.MIC));
+        Collections.singletonList(Target.MIC), null);
     analyzeValidClawLoopFusion("claw loop-fusion target(cpu,cpu)", null, false,
-        0, Collections.singletonList(Target.CPU));
+        0, Collections.singletonList(Target.CPU), null);
     analyzeValidClawLoopFusion("claw loop-fusion target(cpu,gpu)", null, false,
-        0, Arrays.asList(Target.CPU, Target.GPU));
+        0, Arrays.asList(Target.CPU, Target.GPU), null);
     analyzeValidClawLoopFusion("claw loop-fusion target(cpu,gpu,mic)", null,
-        false, 0, Arrays.asList(Target.CPU, Target.GPU, Target.MIC));
+        false, 0, Arrays.asList(Target.CPU, Target.GPU, Target.MIC), null);
     analyzeValidClawLoopFusion("claw loop-fusion target(cpu,gpu) collapse(3) " +
-        "group(g1)", "g1", true, 3, Arrays.asList(Target.CPU, Target.GPU));
+        "group(g1)", "g1", true, 3, Arrays.asList(Target.CPU, Target.GPU), null);
+
+    // Constraint clause
+    analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(block)",
+        "g1", false, 0, null, ClawConstraint.BLOCK);
+    analyzeValidClawLoopFusion("claw loop-fusion group(g1) constraint(none)",
+        "g1", false, 0, null, ClawConstraint.NONE);
+    analyzeValidClawLoopFusion("claw loop-fusion constraint(block)",
+        null, false, 0, null, ClawConstraint.BLOCK);
+    analyzeValidClawLoopFusion("claw loop-fusion constraint(none)",
+        null, false, 0, null, ClawConstraint.NONE);
 
     // Unvalid directives
     analyzeUnvalidClawLanguage("claw loop-fusiongroup(g1)");
@@ -90,7 +101,8 @@ public class ClawLanguageTest {
    */
   private void analyzeValidClawLoopFusion(String raw, String groupName,
                                           boolean collapse, int n,
-                                          List<Target> targets)
+                                          List<Target> targets,
+                                          ClawConstraint constraint)
   {
     try {
       Xnode p = XmlHelper.createXpragma();
@@ -114,6 +126,13 @@ public class ClawLanguageTest {
       } else {
         assertFalse(l.hasCollapseClause());
       }
+      if(constraint != null){
+        assertTrue(l.hasConstraintClause());
+        assertEquals(constraint, l.getConstraintClauseValue());
+      } else {
+        assertFalse(l.hasConstraintClause());
+      }
+
       assertTargets(l, targets);
     } catch(IllegalDirectiveException idex) {
       fail();
@@ -1209,11 +1228,11 @@ public class ClawLanguageTest {
   @Test
   public void ContinuationTest() {
     String continuedPragma = "claw loop-fusion   claw collapse(2)";
-    analyzeValidClawLoopFusion(continuedPragma, null, true, 2, null);
+    analyzeValidClawLoopFusion(continuedPragma, null, true, 2, null, null);
 
     String continuedPragma2 = "claw loop-fusion   claw collapse(2) target(cpu)";
     analyzeValidClawLoopFusion(continuedPragma2, null, true, 2,
-        Collections.singletonList(Target.CPU));
+        Collections.singletonList(Target.CPU), null);
   }
 
 }

--- a/test/loops/CMakeLists.txt
+++ b/test/loops/CMakeLists.txt
@@ -15,6 +15,7 @@ add_subdirectory(fusion5)
 add_subdirectory(fusion6)
 add_subdirectory(fusion7)      # with target clause
 add_subdirectory(fusion8)      # impossible fusion because of assignment
+add_subdirectory(fusion9)
 add_subdirectory(hoist1)
 add_subdirectory(hoist2)
 add_subdirectory(hoist3)       # with target clause

--- a/test/loops/CMakeLists.txt
+++ b/test/loops/CMakeLists.txt
@@ -16,6 +16,7 @@ add_subdirectory(fusion6)
 add_subdirectory(fusion7)      # with target clause
 add_subdirectory(fusion8)      # impossible fusion because of assignment
 add_subdirectory(fusion9)
+add_subdirectory(fusion10)
 add_subdirectory(hoist1)
 add_subdirectory(hoist2)
 add_subdirectory(hoist3)       # with target clause

--- a/test/loops/fusion10/CMakeLists.txt
+++ b/test/loops/fusion10/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_NAME fusion10)
+set(TEST_DEBUG OFF)
+set(OUTPUT_TEST OFF)
+set(IGNORE_TEST OFF)
+include(${CMAKE_SOURCE_DIR}/test/base_test.cmake)

--- a/test/loops/fusion10/original_code.f90
+++ b/test/loops/fusion10/original_code.f90
@@ -1,0 +1,40 @@
+program loop_opt
+  implicit none
+  integer :: i,k,j,d
+  integer :: iend,jend,kend
+  logical :: flag
+  integer :: sum(30)
+
+  iend = 20
+  jend = 40
+  kend = 30
+  flag = .FALSE.
+
+  DO j=1,jend
+    DO k=1, kend
+      ! loop #1 body here
+      d = d + 1
+      sum(k) = 0
+    ENDDO
+
+    !$claw loop-hoist(k) reshape(sum(0))
+    DO i=1, iend
+      !$claw loop-fusion group(g2) constraint(none)
+      DO k=1, kend
+        ! loop #2 body here
+        sum(k) = sum(k)+i
+      END DO
+
+      if (flag) then
+        print*,'I did it'
+      end if
+
+      !$claw loop-fusion group(g2) constraint(none)
+      DO k=1, kend
+        ! loop #3 body here
+        d = sum(k) + d
+      END DO
+    ENDDO
+    !$claw end loop-hoist
+  ENDDO
+end program loop_opt

--- a/test/loops/fusion10/reference.f90
+++ b/test/loops/fusion10/reference.f90
@@ -1,0 +1,33 @@
+PROGRAM loop_opt
+ INTEGER :: i
+ INTEGER :: k
+ INTEGER :: j
+ INTEGER :: d
+ INTEGER :: iend
+ INTEGER :: jend
+ INTEGER :: kend
+ LOGICAL :: flag
+ INTEGER :: sum
+
+ iend = 20
+ jend = 40
+ kend = 30
+ flag = .FALSE.
+ DO j = 1 , jend , 1
+  DO k = 1 , kend , 1
+   d = d + 1
+   sum = 0
+  END DO
+  DO k = 1 , kend , 1
+   DO i = 1 , iend , 1
+!$claw loop-fusion group(g2) constraint(none)
+    sum = sum + i
+    d = sum + d
+    IF ( flag ) THEN
+     PRINT * ,"I did it"
+    END IF
+   END DO
+  END DO
+ END DO
+END PROGRAM loop_opt
+

--- a/test/loops/fusion9/CMakeLists.txt
+++ b/test/loops/fusion9/CMakeLists.txt
@@ -1,0 +1,5 @@
+set(TEST_NAME fusion9)
+set(TEST_DEBUG ON)
+set(OUTPUT_TEST OFF)
+set(IGNORE_TEST OFF)
+include(${CMAKE_SOURCE_DIR}/test/base_test.cmake)

--- a/test/loops/fusion9/original_code.f90
+++ b/test/loops/fusion9/original_code.f90
@@ -4,11 +4,13 @@ program test
 
   ldo = .true.
 
+  !$claw loop-fusion group(g1) constraint(none)
+  do i = 1, 10
+    print*,'Loop body #1'
+  end do
+
   if ( ldo ) then
-    !$claw loop-fusion group(g1) constraint(none)
-    do i = 1, 10
-      print*,'Loop body #1'
-    end do
+    print*,'I did'
   end if
 
   !$claw loop-fusion group(g1) constraint(none)

--- a/test/loops/fusion9/original_code.f90
+++ b/test/loops/fusion9/original_code.f90
@@ -1,0 +1,19 @@
+program test
+  integer :: i
+  logical :: ldo
+
+  ldo = .true.
+
+  if ( ldo ) then
+    !$claw loop-fusion group(g1) constraint(none)
+    do i = 1, 10
+      print*,'Loop body #1'
+    end do
+  end if
+
+  !$claw loop-fusion group(g1) constraint(none)
+  do i = 1, 10
+    print*,'Loop body #2'
+  end do
+
+end program test

--- a/test/loops/fusion9/reference.f90
+++ b/test/loops/fusion9/reference.f90
@@ -1,0 +1,14 @@
+PROGRAM test
+ INTEGER :: i
+ LOGICAL :: ldo
+
+ ldo = .TRUE.
+ IF ( ldo ) THEN
+!$claw loop-fusion group(g1) constraint(none)
+  DO i = 1 , 10 , 1
+   PRINT * ,"Loop body #1"
+   PRINT * ,"Loop body #2"
+  END DO
+ END IF
+END PROGRAM test
+

--- a/test/loops/fusion9/reference.f90
+++ b/test/loops/fusion9/reference.f90
@@ -3,12 +3,13 @@ PROGRAM test
  LOGICAL :: ldo
 
  ldo = .TRUE.
- IF ( ldo ) THEN
 !$claw loop-fusion group(g1) constraint(none)
-  DO i = 1 , 10 , 1
-   PRINT * ,"Loop body #1"
-   PRINT * ,"Loop body #2"
-  END DO
+ DO i = 1 , 10 , 1
+  PRINT * ,"Loop body #1"
+  PRINT * ,"Loop body #2"
+ END DO
+ IF ( ldo ) THEN
+  PRINT * ,"I did"
  END IF
 END PROGRAM test
 


### PR DESCRIPTION
- Allow constraint clause for the loop-fusion directive
- Release the direct sibling constraint for a loop-fusion transformation where both directive are set to `constraint(none)`
- Allow `loop-hoist` to work with nested `DO` in `DO`
Related to feature request by Huadong (ECMWF) #121 & #122 

Related test case: 
- `test/loops/fusion9`
- `test/loops/fusion10`
- `test/loops/hoist4`