### PR TITLE
Exit correctly run.shellcheck.sh in case of error

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ matrix:
       addons:
         apt:
           sources:
+            - ubuntu-toolchain-r-test
             - debian-sid
           packages:
             - gcc-4.9

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,8 @@ matrix:
         - FC_COMPILER=gfortran-4.9
       addons:
         apt:
-          sources: ['ubuntu-toolchain-r-test']
+          sources:
+            - debian-sid
           packages:
             - gcc-4.9
             - g++-4.9

--- a/scripts/run.shellcheck.sh
+++ b/scripts/run.shellcheck.sh
@@ -9,6 +9,7 @@
 # author: clementval
 #
 
+shellcheck -V
 shellcheck offline.sh
 shellcheck pack_release.sh
 cd ../driver/bin || exit 1

--- a/scripts/run.shellcheck.sh
+++ b/scripts/run.shellcheck.sh
@@ -10,10 +10,25 @@
 #
 
 shellcheck -V
-shellcheck offline.sh
-shellcheck pack_release.sh
+if ! shellcheck offline.sh
+then
+  exit 1
+fi
+if ! shellcheck pack_release.sh
+then
+  exit 1
+fi
 cd ../driver/bin || exit 1
-shellcheck ../etc/claw_f.conf
-shellcheck ../libexec/claw_f_lib.sh.in
-shellcheck clawfc.in ../libexec/claw_f_lib.sh.in ../etc/claw_f.conf.in
+if ! shellcheck ../etc/claw_f.conf
+then
+  exit 1
+fi
+if ! shellcheck ../libexec/claw_f_lib.sh.in
+then
+  exit 1
+fi
+if ! shellcheck clawfc.in ../libexec/claw_f_lib.sh.in ../etc/claw_f.conf.in
+then
+  exit 1
+fi
 cd - || exit 1


### PR DESCRIPTION
- Exit script when errors are detected
- Add correct shellcheck version to CI 